### PR TITLE
Retrieve service configuration once on startup

### DIFF
--- a/cmd/dp-geodata-api/main.go
+++ b/cmd/dp-geodata-api/main.go
@@ -20,13 +20,6 @@ var (
 	GitCommit string
 	// Version represents the version of the service that is running
 	Version string
-
-// TODO: remove below explainer before committing
-/* NOTE: replace the above with the below to run code with for example vscode debugger.
-BuildTime string = "1601119818"
-GitCommit string = "6584b786caac36b6214ffe04bf62f058d4021538"
-Version   string = "v0.1.0"
-*/
 )
 
 func main() {

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	EnableDatabase             bool          `envconfig:"ENABLE_DATABASE"`
 	MaxMetrics                 int           `envconfig:"MAX_METRICS"`
 	WriteTimeout               time.Duration `envconfig:"WRITE_TIMEOUT"`
-	APIToken                   string        `envconfig:"API_TOKEN"`
+	APIToken                   string        `envconfig:"API_TOKEN"                     json:"-"`
 	EnableHeaderAuth           bool          `envconfig:"ENABLE_HEADER_AUTH"`
 	CacheSize                  int           `envconfig:"CACHE_SIZE"`
 	CacheTTL                   time.Duration `envconfig:"CACHE_TTL"`

--- a/handlers/cache_control.go
+++ b/handlers/cache_control.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/ONSdigital/dp-geodata-api/cache"
-	"github.com/ONSdigital/dp-geodata-api/config"
 	"github.com/ONSdigital/dp-geodata-api/sentinel"
 	"github.com/ONSdigital/log.go/v2/log"
 )
@@ -21,9 +20,8 @@ type generateFunc func() ([]byte, error)
 // respond returns cached data if it is available, or generates and caches new data.
 func (svr *Server) respond(w http.ResponseWriter, r *http.Request, contentType string, generate generateFunc) {
 
-	// add CORS header if doing that
-	c, _ := config.Get()
-	if c.DoCors {
+	// add CORS header if application configured to do so
+	if svr.doCors {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -36,9 +36,8 @@ type Service struct {
 // Run the service
 func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceList, buildTime, gitCommit, version string, svcErrors chan error) (*Service, error) {
 
+	log.Info(ctx, "config on startup", log.Data{"config": cfg, "build_time": buildTime, "git-commit": gitCommit})
 	log.Info(ctx, "running service")
-
-	log.Info(ctx, "using service configuration", log.Data{"config": cfg})
 
 	var cant *cantabular.Client
 	if cfg.EnableCantabular {
@@ -112,7 +111,8 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 
 	// Setup the API
-	a := handlers.New(true, queryGeodata, md, cm, pc) // always include private handlers for now
+	a := handlers.New(cfg.APIToken, cfg.BindAddr, cfg.EnableHeaderAuth, cfg.DoCors,
+		true, queryGeodata, md, cm, pc) // always include private handlers for now
 
 	// Setup health checks
 	hc, err := serviceList.GetHealthCheck(cfg, buildTime, gitCommit, version)


### PR DESCRIPTION
### What

We should be reusing the reference to *config object and it's fields across the application instead of reinstantiating
a new config object which can lead to inheriting new configuration changes that result in weird behaviour by the application

### How to review

Check changes make sense
Run unit and component tests

### Who can review

Anyone
