### PR TITLE
add support for BASEURL so swagger self links can be fixed

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 // Config represents service configuration for dp-geodata-api
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
+	BaseURL                    string        `envconfig:"BASEURL"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -301,38 +302,46 @@ func Test_ParseBaseURL_Error(t *testing.T) {
 		baseurl  string
 		bindaddr string
 	}{
-		"BIND_ADDR missing port": {"host", ""},
-		"BASEURL missing port":   {"", "https://host"},
+		"BASEURL and BIND_ADDR empty":   {"", ""},
+		"BASEURL parse error":           {"", "scheme:/host"},
+		"BASEURL wrong scheme":          {"", "ftp://localhost"},
+		"BASEURL user/pass not allowed": {"", "http://user@localhost"},
+		"BASEURL host expected":         {"", "http://:80"},
+		"BASEURL query not allowed":     {"", "http://localhost?foo"},
+		"BASEURL fragment not allowed":  {"", "http://localhost#frag"},
+		"BIND_ADDR missing port":        {"host", ""},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, _, err := service.ParseBaseURL(test.baseurl, test.bindaddr)
+			server, prefix, err := service.ParseBaseURL(test.baseurl, test.bindaddr)
 			if err == nil {
-				t.Error("expected error")
+				t.Errorf("expected error, got server %q prefix %q", server, prefix)
 			}
 		})
 	}
 }
 
 func Test_ParseBaseURL(t *testing.T) {
+	// missing host in BIND_ADDR defaults to hostname
+	me, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var tests = map[string]struct {
 		baseurl  string
 		bindaddr string
 		server   string
 		prefix   string
 	}{
-		"both empty, default": {"", "", "http://localhost:25252", ""},
-
-		// only BIND_ADDR
-		"just BIND_ADDR port":     {":123", "", "http://localhost:123", ""},
-		"BIND_ADDR host and port": {"host:8000", "", "http://host:8000", ""},
-
-		// only BASEURL
+		"BASEURL scheme, host":               {"", "http://host", "http://host", ""},
 		"BASEURL scheme, host, port":         {"", "https://host:100", "https://host:100", ""},
 		"BASEURL scheme, host, port, prefix": {"", "https://host:200/v1/geodata", "https://host:200", "/v1/geodata"},
 
-		// BIND_ADDR and BASEURL
+		"BIND_ADDR only port":     {":123", "", "http://" + me + ":123", ""},
+		"BIND_ADDR host and port": {"host:8000", "", "http://host:8000", ""},
+
 		"BASEURL overrides BIND_ADDR": {"localhost:25252", "https://api:27000/foo", "https://api:27000", "/foo"},
 	}
 


### PR DESCRIPTION
### What

When the API is behind something like the api router, it generates wrong self-links in the /swaggerui app.

This add support for an optional BASEURL environment variable which can inform swaggerui of its public URL, and can be used to set the "/v1/geodata" optional prefix.