### PR TITLE
allow github access from atlas host, update docs

### DIFF
--- a/atlas-host/Makefile
+++ b/atlas-host/Makefile
@@ -1,7 +1,7 @@
 # stolen from https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help
 help: ## This help
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-z0-9A-Z_-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-z0-9A-Z_.-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 .PHONY: ssh.cfg
 ssh.cfg:        ## generate ssh.cfg for atlas and container hosts

--- a/atlas-host/README.md
+++ b/atlas-host/README.md
@@ -171,6 +171,17 @@ If you need to add another shell user to the Atlas image:
 
 It's up to the new user to log in and set up their own environment.
 
+## Accessing github from the Atlas host or a container
+
+Outbound port 22 is blocked at the VPC level, so we need to access github on port 443.
+Add this tweak to your `~/.ssh/config` file in your container:
+
+	Host github.com
+		Hostname ssh.github.com
+		Port 443
+		User git
+
+See [Using SSH over the HTTPS port](https://docs.github.com/en/authentication/troubleshooting-ssh/using-ssh-over-the-https-port)
 
 ## Credits
 

--- a/atlas-host/gencfg.sh
+++ b/atlas-host/gencfg.sh
@@ -41,6 +41,8 @@ Host container
     Hostname $ip
     StrictHostKeyChecking no
     UserKnownHostsFile /dev/null
+    # git needs ssh credentials
+    ForwardAgent yes
 EOF
 }
 

--- a/cmd/gentiles/README.md
+++ b/cmd/gentiles/README.md
@@ -10,7 +10,7 @@
 
 ## Get Tile Bounding Boxes
 
-1. Get the current `data-tile-grids/quadsDataTileGrids.json` file from the `dp-census-atlas` repo.
+1. Get the current `data-tile-grids/quadsDataTileGrid.json` file from the `dp-census-atlas` repo.
 
 ## Generate Geocode Listing
 
@@ -28,7 +28,7 @@ _This takes a long time and can make your CPU very hot._
 
 2. Run
 
-        go run ./main.go -C categories.txt -T quadsDataTileGrids.json -G geos.txt -j 10 -o out 2>main.stderr
+        go run ./main.go -C categories.txt -T quadsDataTileGrid.json -G geos.txt -j 10 -o out 2>main.stderr
 
     The `-j` option is concurrency.
     Low concurrency takes a long time, but high concurrency runs very hot.

--- a/end-to-end.md
+++ b/end-to-end.md
@@ -4,13 +4,13 @@ This is a complete step-by-step guide to all the steps related to building a dat
 
 Some steps do not have to be done every single time, but are included here for completeness.
 
-Unless otherwise stated, `cd` commands are relative to a checked out `dp-find-insights-poc-api` repo.
+Unless otherwise stated, `cd` commands are relative to a checked out `dp-geodata-api` repo.
 
 Environment variables are important! Always verify the `PG_*` and `POSTGRES_PASSWORD` variables before a risky step.
 
 ## Prerequisites
 
-* [dp-find-insights-poc-api](https://github.com/ONSdigitsl/dp-find-insights-poc-api) and
+* [dp-geodata-api](https://github.com/ONSdigitsl/dp-geodata-api) and
   [dp-setup](https://github.com/ONSdigital/dp-setup) repos checked out
 
 * postgres cli tools installed
@@ -161,7 +161,7 @@ Verify your environment variables point to the tunnel and use the RDS credential
 
 Then run the import:
 
-    cd <dp-find-insights-poc-api repo>
+    cd <dp-geodata-api repo>
     cd dataingest/dbsetup
     
     # this is the sql dump file created in the Export Database step above
@@ -186,7 +186,7 @@ The only requirement is a running local API that talks to RDS.
 
 Just run this in another terminal.  You should not get any errors.
 
-    cd <dp-find-insights-poc-api repo>
+    cd <dp-geodata-api repo>
     make test-local
 
 ## Tear down RDS

--- a/indigestion.sh
+++ b/indigestion.sh
@@ -11,6 +11,10 @@ fi
 otime=$SECONDS
 set -e -x
 PGPASSWORD=$POSTGRES_PASSWORD dropdb --username postgres --if-exists "$PGDATABASE"
+# update-schema has a CREATE DATABASE, but it runs as the postgres user.
+# In RDS Aurora, the postgres user doesn't have permissions to do this.
+# So create the database here as the atlas user, and let update-schema print an error.
+psql --dbname postgres -c "CREATE DATABASE $PGDATABASE";
 yes | make update-schema
 go run ./dataingest/addtodb
 (yes | make update-schema) 


### PR DESCRIPTION
### What

Allow ssh access to github over port 443 because of vpc port 22 block.
Some small documentation and script fixes for issues encountered when running the ingest and data tile generation from the Atlas host.