### PR TITLE
local volume in atlas container

### DIFF
--- a/atlas-host/Dockerfile
+++ b/atlas-host/Dockerfile
@@ -105,3 +105,9 @@ RUN ln -s /data/dl /home/dl && \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y sudo && \
     echo "%atlas ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/atlas
+
+#
+# Install sshd.sh as the container init script
+#
+COPY sshd.sh /usr/local/etc/sshd.sh
+RUN chmod 0755 /usr/local/etc/sshd.sh

--- a/atlas-host/README.md
+++ b/atlas-host/README.md
@@ -143,6 +143,15 @@ Stop your container like this:
 	make down
 
 
+## local Volume
+
+Since EFS is relatively slow, containers also have a `/local` volume that uses space
+on the docker EBS volume (under `/var/lib/docker` on the atlas host itself).
+
+You can point the data-tiles scripts to `/local` by using the `D` command line variable:
+
+	make GEOVERSION=2021 D=/local
+
 ## scp and sftp
 
 You can transfer files to and from your container with `scp` and `sftp`.

--- a/atlas-host/docker-compose.yml
+++ b/atlas-host/docker-compose.yml
@@ -7,8 +7,14 @@ services:
       context: .
     image: atlas-${ATLAS_USER}:latest
     volumes:
+      - type: volume
+        source: local
+        target: /local
       - type: bind
         source: /data
         target: /data
-    command: /data/sshd.sh
+    command: [ "sh", "-c", "/bin/chown ${ATLAS_USER}:${ATLAS_USER} /local; /usr/local/etc/sshd.sh" ]
     init: true
+
+volumes:
+  local:

--- a/atlas-host/sshd.sh
+++ b/atlas-host/sshd.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+#
+# sshd.sh -- fire up sshd in an atlas container
+
+mkdir -p /run/sshd
+chmod 0755 /run/sshd
+
+exec /usr/sbin/sshd -D


### PR DESCRIPTION
* create a per-user /local volume in data-tiles containers
* added sshd.sh to the atlas image

### What

Create /local as a volume in atlas containers. This uses the space already allocated to docker (/var/lib/docker) and is faster than the EFS volume on /data.

Added sshd.sh to the atlas image as the container's init script. This starts up sshd so we can login to our containers. (This script used to be called from /data/sshd.sh, but it should be part of the container.)