### PR TITLE
extract-categories cli

### DIFF
--- a/data-tiles/GNUmakefile
+++ b/data-tiles/GNUmakefile
@@ -122,6 +122,7 @@ dirs:
 # binaries
 #
 BINARIES=\
+	extract-categories \
 	fake-data \
 	generate-breaks \
 	generate-tiles \

--- a/data-tiles/cmd/extract-categories/main.go
+++ b/data-tiles/cmd/extract-categories/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/ONSdigital/dp-geodata-api/data-tiles/content"
+)
+
+func main() {
+	c, err := content.Load(os.Stdin)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, cat := range c.Categories() {
+		fmt.Println(cat)
+	}
+}

--- a/data-tiles/cmd/fake-data/main.go
+++ b/data-tiles/cmd/fake-data/main.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	cats := getCats(c)
+	cats := c.Categories()
 	log.Printf("\tfound %d categories\n", len(cats))
 
 	geos, err := loadGeos(*geodir)
@@ -37,22 +37,6 @@ func main() {
 	if err := genFake(cats, geos, *seed); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func getCats(c *content.Content) []string {
-	var cats []string
-	for _, group := range c.TopicGroups {
-		for _, topic := range group.Topics {
-			for _, variable := range topic.Variables {
-				for _, classification := range variable.Classifications {
-					for _, cat := range classification.Categories {
-						cats = append(cats, cat.Code)
-					}
-				}
-			}
-		}
-	}
-	return cats
 }
 
 func loadGeos(dir string) ([]string, error) {

--- a/data-tiles/content/content.go
+++ b/data-tiles/content/content.go
@@ -88,3 +88,19 @@ func (c *Content) Save(w io.Writer) error {
 	enc.SetIndent("", "    ")
 	return enc.Encode(c)
 }
+
+func (c *Content) Categories() []string {
+	var cats []string
+	for _, group := range c.TopicGroups {
+		for _, topic := range group.Topics {
+			for _, variable := range topic.Variables {
+				for _, classification := range variable.Classifications {
+					for _, cat := range classification.Categories {
+						cats = append(cats, cat.Code)
+					}
+				}
+			}
+		}
+	}
+	return cats
+}


### PR DESCRIPTION
### What

This is just part of refactoring metrics processing into its own makefile like we did with geos.

This PR moves the method which extracts categories from content.json into the content pkg, and introduces a tiny extract-categories cli which just takes content.json and prints its categories.