### PR TITLE
refactor metrics in data-tiles makefile

### DIFF
--- a/data-tiles/GNUmakefile
+++ b/data-tiles/GNUmakefile
@@ -9,11 +9,15 @@
 #	binaries -- compile Go programs (you may need -B)
 #
 #	download -- download geojson and metrics files
-#	extract -- extract CSVs from metrics zip files
-#	standard -- normalise downloaded geojson (add bbox, set geotype, etc)
+#	download-met -- download just metrics
+#	download-geo -- download just geojson files
+#
+#	process-geo -- normalise downloaded geojson (add bbox, set geotype, etc)
+#	process-met -- process metrics files to standard CSVs
+#
+#	metrics -- split metrics CSVs into single-metric files
 #
 #	geos -- generate geojson files for every geography in standard geojson
-#	metrics -- split downloaded CSVs into single-metric files
 #	tiles - generate data tile CSVs
 #	breaks -- generate break
 #
@@ -26,6 +30,7 @@
 #	DATA_TILE_GRID -- name of quads and layers file (default "DataTileGrid.json")
 #	CATEGORIES -- name of categories file (default "categories.txt")
 #	GEOVERSION -- geography version (default "2011")
+#	METVERSION -- metrics version (default "2011")
 
 .DEFAULT_GOAL=all
 
@@ -36,46 +41,7 @@ DATA_TILE_GRID?=DataTileGrid.json
 CATEGORIES?=categories.txt
 
 GEOVERSION?=2011
-
-#
-# Files to download
-#
-
-# Location of nomis zips
-NOMIS_URL=https://www.nomisweb.co.uk/output/census/2011
-
-# List of nomis zips to download, taken from Viv's v4 google spreadsheet.
-NOMIS_ZIPS=\
-	ks103ew_2011_oa.zip \
-	ks202ew_2011_oa.zip \
-	ks206ew_2011_oa.zip \
-	ks207wa_2011_oa.zip \
-	ks608ew_2011_oa.zip \
-	qs101ew_2011_oa.zip \
-	qs103ew_2011_oa.zip \
-	qs104ew_2011_oa.zip \
-	qs113ew_2011_oa.zip \
-	qs119ew_2011_oa.zip \
-	qs201ew_2011_oa.zip \
-	qs202ew_2011_oa.zip \
-	qs203ew_2011_oa.zip \
-	qs208ew_2011_oa.zip \
-	qs301ew_2011_oa.zip \
-	qs302ew_2011_oa.zip \
-	qs303ew_2011_oa.zip \
-	qs402ew_2011_oa.zip \
-	qs403ew_2011_oa.zip \
-	qs406ew_2011_oa.zip \
-	qs411ew_2011_oa.zip \
-	qs415ew_2011_oa.zip \
-	qs416ew_2011_oa.zip \
-	qs501ew_2011_oa.zip \
-	qs601ew_2011_oa.zip \
-	qs604ew_2011_oa.zip \
-	qs605ew_2011_oa.zip \
-	qs701ew_2011_oa.zip \
-	qs702ew_oa.zip \
-	qs803ew_2011_oa.zip \
+METVERSION?=2011
 
 #
 # Directory locations
@@ -85,10 +51,12 @@ DD=$D/downloads
 DDG=$(DD)/geo
 DDGV=$(DDG)/$(GEOVERSION)
 DDM=$(DD)/metrics
+DDMV=$(DDM)/$(METVERSION)
 DP=$D/processed
 DPG=$(DP)/geo
 DPGV=$(DPG)/$(GEOVERSION)
 DPM=$(DP)/metrics
+DPMV=$(DPM)/$(METVERSION)
 DO=$D/output
 DOG=$(DO)/geo
 DOGV=$(DOG)/$(GEOVERSION)
@@ -96,6 +64,7 @@ DOB=$(DO)/breaks
 DOT=$(DO)/tiles
 
 include geo-$(GEOVERSION).mk
+include met-$(METVERSION).mk
 
 #
 # do everything
@@ -116,7 +85,7 @@ clean::
 #
 .PHONY: dirs
 dirs:
-	mkdir -p $(DDGV) $(DDM) $(DPGV) $(DPM) $(DOGV) $(DOB) $(DOT)
+	mkdir -p $(DDGV) $(DDMV) $(DPGV) $(DPMV) $(DOGV) $(DOB) $(DOT)
 
 #
 # binaries
@@ -143,46 +112,22 @@ clean::
 	rm -f $(BINARIES)
 
 #
-# download
+# download targets
 #
 
-# How to download .zip files
-%.zip:
-	./atomic.sh "$@" curl $(NOMIS_URL)/`basename "$@"`
-
-# paths to local downloaded zip files
-ZIP_PATHS=$(foreach zip,$(NOMIS_ZIPS),$(DDM)/$(zip))
-
-.PHONY: download
-download: $(ZIP_PATHS) $(GEO_DOWNLOADS)
-realclean::
-	rm -f $(foreach path,$(ZIP_PATHS),"$(path)")
+.PHONY: download-met download-geo download
+download-geo: $(GEO_DOWNLOADS)
+download-met: $(MET_DOWNLOADS)
+download: $(GEO_DOWNLOADS) $(MET_DOWNLOADS)
 
 #
-# extract
+# processing and normalising
 #
 
-# Paths to extract directories.
-# Zip files are extracted into a directory with an .extracted suffix.
-EXTRACT_PATHS=$(patsubst %.zip,%.extracted,$(ZIP_PATHS))
-
-# how to extract a zip file
-$(EXTRACT_PATHS): %.extracted: %.zip
-	./atomic-rm.sh "$@".tmp
-	unzip -d "$@".tmp "$<"
-	mv "$@".tmp "$@"
-
-.PHONY: extract
-extract: $(EXTRACT_PATHS)
-clean::
-	./atomic-rm.sh $(foreach path,$(EXTRACT_PATHS),"$(path)")
-
-#
-# standard
-#
-
-.PHONY: standard
-standard: $(GEO_PROCESSED)
+.PHONY: process-geo process-met process
+process-geo: $(GEO_PROCESSED)
+process-met: $(MET_PROCESSED)
+process: $(GEO_PROCESSED) $(MET_PROCESSED)
 
 #
 # geos
@@ -213,23 +158,22 @@ clean::
 #
 # All the single-metric files end up in the same directory, so it is all or nothing.
 
-.PHONY: metrics
-metrics: $(DPM)/.done
+.PHONY: split-metrics
+split-metrics: $(DPMV)/.done
 
-DPM_TMP=$(DPM).tmp
+DPMV_TMP=$(DPMV).tmp
 
-# The single-metric files really depend on all *DATA.CSV files found under $DDM.
-# But $(EXTRACT_PATHS) work better because previous rules operate on these directories
-# and not on the CSV files.
-$(DPM)/.done: $(EXTRACT_PATHS) split-metrics
-	./atomic-rm.sh "$(DPM_TMP)"
-	mkdir "$(DPM_TMP)"
-	./split-metrics -s "$(DDM)" -d "$(DPM_TMP)"
-	touch "$(DPM_TMP)"/.done
-	./atomic-rm.sh "$(DPM)"
-	mv "$(DPM_TMP)" "$(DPM)"
+# XXX may need to change split-metrics to take list of directories and/or different
+# XXX glob name other than *DATA.CSV
+$(DPMV)/.done: $(MET_PROCESSED) split-metrics
+	./atomic-rm.sh "$(DPMV_TMP)"
+	mkdir "$(DPMV_TMP)"
+	./split-metrics -s "$(DDMV)" -d "$(DPMV_TMP)"
+	touch "$(DPMV_TMP)"/.done
+	./atomic-rm.sh "$(DPMV)"
+	mv "$(DPMV_TMP)" "$(DPMV)"
 clean::
-	./atomic-rm.sh "$(DPM_TMP)" "$(DPM)"
+	./atomic-rm.sh "$(DPMV_TMP)" "$(DPMV)"
 
 #
 # tiles

--- a/data-tiles/GNUmakefile
+++ b/data-tiles/GNUmakefile
@@ -12,10 +12,11 @@
 #	download-met -- download just metrics
 #	download-geo -- download just geojson files
 #
-#	process-geo -- normalise downloaded geojson (add bbox, set geotype, etc)
-#	process-met -- process metrics files to standard CSVs
+#	standard -- normalise downloaded geojson and metrics files
+#	standard-geo -- normalise just downloaded geojson (add bbox, set geotype, etc)
+#	standard-met -- normalise just downloaded metrics files to standard CSVs
 #
-#	metrics -- split metrics CSVs into single-metric files
+#	single-metrics -- split standard metrics CSVs into single-metric files
 #
 #	geos -- generate geojson files for every geography in standard geojson
 #	tiles - generate data tile CSVs
@@ -47,19 +48,21 @@ METVERSION?=2011
 # Directory locations
 #
 D?=data
+
 DD=$D/downloads
 DDG=$(DD)/geo
 DDGV=$(DDG)/$(GEOVERSION)
 DDM=$(DD)/metrics
 DDMV=$(DDM)/$(METVERSION)
+
 DP=$D/processed
 DPG=$(DP)/geo
 DPGV=$(DPG)/$(GEOVERSION)
 DPM=$(DP)/metrics
 DPMV=$(DPM)/$(METVERSION)
-DO=$D/output
+
+DO=$D/output/geo-$(GEOVERSION)+met-$(METVERSION)
 DOG=$(DO)/geo
-DOGV=$(DOG)/$(GEOVERSION)
 DOB=$(DO)/breaks
 DOT=$(DO)/tiles
 
@@ -70,7 +73,7 @@ include met-$(METVERSION).mk
 # do everything
 #
 .PHONY: all
-all: dirs $(DOGV)/.done $(DOT)/.done $(DOB)/.done
+all: dirs $(DOG)/.done $(DOT)/.done $(DOB)/.done
 
 #
 # cleanup
@@ -85,7 +88,7 @@ clean::
 #
 .PHONY: dirs
 dirs:
-	mkdir -p $(DDGV) $(DDMV) $(DPGV) $(DPMV) $(DOGV) $(DOB) $(DOT)
+	mkdir -p $(DDGV) $(DDMV) $(DPGV) $(DPMV) $(DOG) $(DOB) $(DOT)
 
 #
 # binaries
@@ -124,10 +127,10 @@ download: $(GEO_DOWNLOADS) $(MET_DOWNLOADS)
 # processing and normalising
 #
 
-.PHONY: process-geo process-met process
-process-geo: $(GEO_PROCESSED)
-process-met: $(MET_PROCESSED)
-process: $(GEO_PROCESSED) $(MET_PROCESSED)
+.PHONY: standard-geo standard-met standard
+standard-geo: $(GEO_STANDARD)
+standard-met: $(MET_STANDARD)
+standard: $(GEO_STANDARD) $(MET_STANDARD)
 
 #
 # geos
@@ -135,37 +138,37 @@ process: $(GEO_PROCESSED) $(MET_PROCESSED)
 # All the output geojson files end up in a a single directory, so it is all or nothing.
 
 .PHONY: geos
-geos: $(DOGV)/.done
+geos: $(DOG)/.done
 
-DOGV_TMP=$(DOGV).tmp
+DOG_TMP=$(DOG).tmp
 
-$(DOGV)/.done: $(GEO_PROCESSED) split-geojson
-	./atomic-rm.sh "$(DOGV_TMP)"
-	mkdir "$(DOGV_TMP)"
-	for f in $(foreach processed,$(GEO_PROCESSED),"$(processed)") ;\
+$(DOG)/.done: $(GEO_STANDARD) split-geojson
+	./atomic-rm.sh "$(DOG_TMP)"
+	mkdir "$(DOG_TMP)"
+	for f in $(foreach processed,$(GEO_STANDARD),"$(processed)") ;\
 	do \
 		echo "splitting $$f" ;\
-		./split-geojson -d "$(DOGV_TMP)" < "$$f" ;\
+		./split-geojson -d "$(DOG_TMP)" < "$$f" ;\
 	done
-	touch "$(DOGV_TMP)"/.done
-	./atomic-rm.sh "$(DOGV)"
-	mv "$(DOGV_TMP)" "$(DOGV)"
+	touch "$(DOG_TMP)"/.done
+	./atomic-rm.sh "$(DOG)"
+	mv "$(DOG_TMP)" "$(DOG)"
 clean::
-	./atomic-rm.sh "$(DOGV_TMP)" "$(DOGV)"
+	./atomic-rm.sh "$(DOG_TMP)" "$(DOG)"
 
 #
 # metrics
 #
 # All the single-metric files end up in the same directory, so it is all or nothing.
 
-.PHONY: split-metrics
-split-metrics: $(DPMV)/.done
+.PHONY: single-metrics
+single-metrics: $(DPMV)/.done
 
 DPMV_TMP=$(DPMV).tmp
 
 # XXX may need to change split-metrics to take list of directories and/or different
 # XXX glob name other than *DATA.CSV
-$(DPMV)/.done: $(MET_PROCESSED) split-metrics
+$(DPMV)/.done: $(MET_STANDARD) split-metrics
 	./atomic-rm.sh "$(DPMV_TMP)"
 	mkdir "$(DPMV_TMP)"
 	./split-metrics -s "$(DDMV)" -d "$(DPMV_TMP)"
@@ -185,8 +188,8 @@ tiles: $(DOT)/.done
 DOT_TMP=$(DOT).tmp
 
 $(DOT)/.done: \
-		$(GEO_PROCESSED) \
-		$(DPM)/.done \
+		$(GEO_STANDARD) \
+		$(DPMV)/.done \
 		$(DATA_TILE_GRID) \
 		$(CATEGORIES) \
 		generate-tiles
@@ -194,7 +197,7 @@ $(DOT)/.done: \
 	mkdir "$(DOT_TMP)"
 	./generate-tiles \
 		-G "$(DPGV)" \
-		-M "$(DPM)" \
+		-M "$(DPMV)" \
 		-c "$(CATEGORIES)" \
 		-q "$(DATA_TILE_GRID)" \
 		-O "$(DOT_TMP)"
@@ -214,8 +217,8 @@ breaks: $(DOB)/.done
 DOB_TMP=$(DOB).tmp
 
 $(DOB)/.done: \
-		$(GEO_PROCESSED) \
-		$(DPM)/.done \
+		$(GEO_STANDARD) \
+		$(DPMV)/.done \
 		$(DATA_TILE_GRID) \
 		$(CATEGORIES) \
 		generate-breaks
@@ -223,7 +226,7 @@ $(DOB)/.done: \
 	mkdir "$(DOB_TMP)"
 	./generate-breaks \
 		-G "$(DPGV)" \
-		-M "$(DPM)" \
+		-M "$(DPMV)" \
 		-c "$(CATEGORIES)" \
 		-q "$(DATA_TILE_GRID)" \
 		-O "$(DOB_TMP)"

--- a/data-tiles/geo-2011.mk
+++ b/data-tiles/geo-2011.mk
@@ -6,7 +6,7 @@
 # Variables this file is expected to set
 #
 #	GEO_DOWNLOADS	list of downloaded geo files
-#	GEO_PROCESSED	list of processed geo files
+#	GEO_STANDARD	list of normalised geo files
 #
 # Each file named in those variables should have targets in this file.
 
@@ -85,9 +85,9 @@ STANDARD_MSOA=$(DPGV)/msoa.geojson
 STANDARD_OA=$(DPGV)/oa.geojson
 
 #
-# Set GEO_PROCESSED so parent make file can use processed files as targets.
+# Set GEO_STANDARD so parent make file can use processed files as targets.
 #
-GEO_PROCESSED=$(STANDARD_LAD) $(STANDARD_LSOA) $(STANDARD_MSOA) $(STANDARD_OA)
+GEO_STANDARD=$(STANDARD_LAD) $(STANDARD_LSOA) $(STANDARD_MSOA) $(STANDARD_OA)
 
 #
 # Rules to process geo files

--- a/data-tiles/geo-2021.mk
+++ b/data-tiles/geo-2021.mk
@@ -6,7 +6,7 @@
 # Variables this file is expected to set
 #
 #	GEO_DOWNLOADS	list of downloaded geo files
-#	GEO_PROCESSED	list of processed geo files
+#	GEO_STANDARD	list of normalised geo files
 #
 # Each file named in those variables should have targets in this file.
 
@@ -94,9 +94,9 @@ STANDARD_MSOA=$(DPGV)/msoa.geojson
 STANDARD_OA=$(DPGV)/oa.geojson
 
 #
-# Set GEO_PROCESSED so parent make file can use processed files as targets.
+# Set GEO_STANDARD so parent make file can use processed files as targets.
 #
-GEO_PROCESSED=$(STANDARD_LAD) $(STANDARD_MSOA) $(STANDARD_OA)
+GEO_STANDARD=$(STANDARD_LAD) $(STANDARD_MSOA) $(STANDARD_OA)
 
 #
 # Rules to process geo files

--- a/data-tiles/met-2011.mk
+++ b/data-tiles/met-2011.mk
@@ -6,9 +6,10 @@
 # Variables this file is expected to set
 #
 #	MET_DOWNLOADS	list of downloaded metrics files
-#	MET_PROCESSED	list of processed standard format metrics files
+#	MET_STANDARD	list of normalised standard format metrics files
 #
 # Each file named in those variables should have targets in this file.
+# And there should be clean and realclean targets to clean these files up.
 
 # Location of nomis zips
 NOMIS_URL=https://www.nomisweb.co.uk/output/census/2011
@@ -59,13 +60,13 @@ realclean::
 
 
 # Zip files are extracted into a directory with an .extracted suffix.
-MET_PROCESSED=$(patsubst %.zip,%.extracted,$(MET_DOWNLOADS))
+MET_STANDARD=$(patsubst %.zip,%.extracted,$(MET_DOWNLOADS))
 
 # how to extract a zip file
-$(MET_PROCESSED): %.extracted: %.zip
+$(MET_STANDARD): %.extracted: %.zip
 	./atomic-rm.sh "$@".tmp
 	unzip -d "$@".tmp "$<"
 	mv "$@".tmp "$@"
 
 clean::
-	./atomic-rm.sh $(foreach path,$(MET_PROCESSED),"$(path)")
+	./atomic-rm.sh $(foreach path,$(MET_STANDARD),"$(path)")

--- a/data-tiles/met-2011.mk
+++ b/data-tiles/met-2011.mk
@@ -1,0 +1,71 @@
+#
+# met-2011.mk -- rules to download and process 2011 metrics
+#
+# This makefile is mean to be included by GNUmakefile; it's not independent
+#
+# Variables this file is expected to set
+#
+#	MET_DOWNLOADS	list of downloaded metrics files
+#	MET_PROCESSED	list of processed standard format metrics files
+#
+# Each file named in those variables should have targets in this file.
+
+# Location of nomis zips
+NOMIS_URL=https://www.nomisweb.co.uk/output/census/2011
+
+# List of nomis zips to download, taken from Viv's v4 google spreadsheet.
+NOMIS_ZIPS=\
+	ks103ew_2011_oa.zip \
+	ks202ew_2011_oa.zip \
+	ks206ew_2011_oa.zip \
+	ks207wa_2011_oa.zip \
+	ks608ew_2011_oa.zip \
+	qs101ew_2011_oa.zip \
+	qs103ew_2011_oa.zip \
+	qs104ew_2011_oa.zip \
+	qs113ew_2011_oa.zip \
+	qs119ew_2011_oa.zip \
+	qs201ew_2011_oa.zip \
+	qs202ew_2011_oa.zip \
+	qs203ew_2011_oa.zip \
+	qs208ew_2011_oa.zip \
+	qs301ew_2011_oa.zip \
+	qs302ew_2011_oa.zip \
+	qs303ew_2011_oa.zip \
+	qs402ew_2011_oa.zip \
+	qs403ew_2011_oa.zip \
+	qs406ew_2011_oa.zip \
+	qs411ew_2011_oa.zip \
+	qs415ew_2011_oa.zip \
+	qs416ew_2011_oa.zip \
+	qs501ew_2011_oa.zip \
+	qs601ew_2011_oa.zip \
+	qs604ew_2011_oa.zip \
+	qs605ew_2011_oa.zip \
+	qs701ew_2011_oa.zip \
+	qs702ew_oa.zip \
+	qs803ew_2011_oa.zip
+
+
+# How to download .zip files
+%.zip:
+	./atomic.sh "$@" curl $(NOMIS_URL)/`basename "$@"`
+
+# paths to local downloaded zip files
+MET_DOWNLOADS=$(foreach zip,$(NOMIS_ZIPS),$(DDMV)/$(zip))
+
+realclean::
+	rm -f $(foreach path,$(MET_DOWNLOADS),"$(path)")
+
+
+# Zip files are extracted into a directory with an .extracted suffix.
+MET_PROCESSED=$(patsubst %.zip,%.extracted,$(MET_DOWNLOADS))
+
+# how to extract a zip file
+$(MET_PROCESSED): %.extracted: %.zip
+	./atomic-rm.sh "$@".tmp
+	unzip -d "$@".tmp "$<"
+	mv "$@".tmp "$@"
+
+clean::
+	./atomic-rm.sh $(foreach path,$(MET_PROCESSED),"$(path)")


### PR DESCRIPTION
### What

Moved the metrics-related macros and rules from GNUmakefle to met-2011.mk in preparation for generating fake metrics and for different metric sets in future.

Also changed output directory to be data/output/geo-GEOVERSION+met-METVERSION. For example "geo-2011+met-2011". So the geo and metric combination can be seen in the directory name.

### How to review

Best test would be to run "make all" to verify 2011 still works, and then "make geos GEOVERSION=2021" to verify the new 2021 geography generation works.

(Don't forget to "make -B binaries" and "make dirs GEOVERSION=2021".)

(But it does tend to heat your machine up.)